### PR TITLE
Stateful grade handling.

### DIFF
--- a/app/static/assets/css/app.css
+++ b/app/static/assets/css/app.css
@@ -37,3 +37,7 @@
         font-size: 1.5em;
     }
 }
+
+input:read-only, input:read-only:focus {
+    color: black;
+}

--- a/app/static/assets/js/main.js
+++ b/app/static/assets/js/main.js
@@ -47,7 +47,10 @@ function displayError(message) {
 
 function displayInfo(message) {
     displayMessage(message, "Info.", "info");
+}
 
+function displayWarning(message) {
+    displayMessage(message, "Warning.", "warning");
 }
 
 function displayMessage(message, title, type) {

--- a/app/static/assets/js/main.js
+++ b/app/static/assets/js/main.js
@@ -39,17 +39,23 @@ if (localStorage.getItem("campus") == null) $('#campusModal').modal('show');
 * Display Errors
 *-----------------------------------*/
 // Use a counter to generate and collapse multiple alerts
-let errorCounter = 0;
+let messageCounter = 0;
 
 function displayError(message) {
-    // Show error
-    let errorId = `error-${errorCounter}`;
-    $("#notification").append(`<div class="alert alert-danger mt-3" id="${errorId}"><strong>Error.</strong> ${message}</div>`);
-    // Fade the error after a second
-    $(`#${errorId}`).fadeTo(1500, 500).slideUp(500, function () {
-        $(`#${errorId}`).slideUp(1000);
-        // Delete the HTML element after its hidden.
-        $(`#${errorId}`).remove();
+    displayMessage(message, "Error.", "danger");
+}
+
+function displayInfo(message) {
+    displayMessage(message, "Info.", "info");
+
+}
+
+function displayMessage(message, title, type) {
+    let messageId = `error-${messageCounter}`;
+    $("#notification").append(`<div class="alert alert-${type} mt-3" id="${messageId}"><strong>${title}</strong> ${message}</div>`);
+    $(`#${messageId}`).fadeTo(1500, 500).slideUp(500, function () {
+        $(`#${messageId}`).slideUp(1000);
+        $(`#${messageId}`).remove();
     });
-    errorCounter++;
+    messageCounter++;
 }

--- a/app/static/assets/js/statistics-by-course.js
+++ b/app/static/assets/js/statistics-by-course.js
@@ -79,9 +79,17 @@ $(function () {
         });
 
         $("#sc-copy-url-form").on("submit", () => {
-            navigator.clipboard.writeText(document.location.href);
-            displayInfo("Copied!");
+            try {
+                navigator.clipboard.writeText(document.location.href);
+                displayInfo("Copied!");
+            } catch (e) {
+                displayError("Failed to copy, try manually.");
+            }
             return false;
+        });
+
+        $("#sc-copy-url-input").on("click", (e) => {
+            e.target.setSelectionRange(0, e.target.value.length)
         });
     }
 

--- a/app/static/assets/js/statistics-by-course.js
+++ b/app/static/assets/js/statistics-by-course.js
@@ -38,6 +38,7 @@ $(function () {
         this.updateState = () => {
             _synchronizing = false;
             window.location.hash = constructHash();
+            $("#sc-copy-url-input").val(document.location.href);
         };
 
         this.resetState = () => {
@@ -75,6 +76,12 @@ $(function () {
             if (constructHash() !== window.location.hash.substring(1)) {
                 this.synchronizeState();
             }
+        });
+
+        $("#sc-copy-url-form").on("submit", () => {
+            navigator.clipboard.writeText(document.location.href);
+            displayInfo("Copied!");
+            return false;
         });
     }
 

--- a/app/static/assets/js/statistics-by-course.js
+++ b/app/static/assets/js/statistics-by-course.js
@@ -20,27 +20,38 @@ $(function () {
             return `${_subject}-${_course}`;
         };
 
-        this.updateSubject = async (subject) => {
+        this.updateSubject = async (subject, dropdown = true) => {
             _subject = subject;
             if (!_synchronizing) {
                 // Reset the course so we get the dropdown
                 _course = null;
             }
-            updateCourseDropdown(subject, _course);
+            if (dropdown) {
+                updateCourseDropdown(subject, _course);
+            }
         };
 
-        this.updateCourse = async (course) => {
+        this.updateCourse = async (course, dropdown = true) => {
             _course = course;
             this.updateState();
-            $('#sc-dropdown-form').submit();
+            if (dropdown) {
+                $('#sc-dropdown-form').submit();
+            }
         };
 
+        /**
+         * Last stage of the state machine that consolidates all
+         * the substates and pushes the state to the browser history stack.
+         */
         this.updateState = () => {
             _synchronizing = false;
             window.location.hash = constructHash();
             $("#sc-copy-url-input").val(document.location.href);
         };
 
+        /**
+         * Resets the state machine and updates the browser history.
+         */
         this.resetState = () => {
             _synchronizing = false;
             let data = [null, null];
@@ -51,6 +62,9 @@ $(function () {
             window.history.replaceState(undefined, undefined, " ");
         };
 
+        /**
+         * Synchronizes the state machine with the URL fragment.
+         */
         this.synchronizeState = () => {
             _synchronizing = true;
             let fragments = window.location.hash.substring(1).split("-");
@@ -78,6 +92,9 @@ $(function () {
             }
         });
 
+        /**
+         * Share URL handlers below.
+         */
         $("#sc-copy-url-form").on("submit", () => {
             try {
                 navigator.clipboard.writeText(document.location.href);
@@ -204,10 +221,12 @@ $(function () {
 
     // Entry via ID
     $("#sc-id-form").on('submit', function () {
-        let idSplit = parseStatisticsByCourseID($('#vg-id-form input').val());
+        let idSplit = parseStatisticsByCourseID($('#sc-id-form input').val());
         if (idSplit === false) {
             displayError("Invalid ID. Check again.");
         } else {
+            stateHandler.updateSubject(idSplit[0], false);
+            stateHandler.updateCourse(idSplit[1], false);
             getCourseStatistics('#sc-id-submit', idSplit[0], idSplit[1]);
         }
         return false;

--- a/app/static/assets/js/view-grades.js
+++ b/app/static/assets/js/view-grades.js
@@ -321,8 +321,8 @@ $(function () {
         if (["subject", "course"].indexOf(id) >= 0) {
             if (id === "course") {
                 data = response.map(item => ({
-                    'id': `${item['course']}${item['detail']}`,
-                    'text': `${item['course']}${item['detail']} - ${item['course_title']}`
+                    'id': `${item['course']}${item['detail'] ? item['detail'] : ''}`,
+                    'text': `${item['course']}${item['detail'] ? item['detail'] : ''} - ${item['course_title']}`
                 }));
             } else {
                 data = response.map(item => ({

--- a/app/static/assets/js/view-grades.js
+++ b/app/static/assets/js/view-grades.js
@@ -59,6 +59,7 @@ $(function () {
             // This shouldn't push a new state to the history stack
             // if the hashes are the same, so we don't need to check
             window.location.hash = constructHash();
+            $("#vg-copy-url-input").val(document.location.href);
         };
 
         this.resetState = () => {
@@ -94,6 +95,12 @@ $(function () {
             if (constructHash() !== window.location.hash.substring(1)) {
                 this.synchronizeState();
             }
+        });
+
+        $("#vg-copy-url-form").on("submit", () => {
+            navigator.clipboard.writeText(document.location.href);
+            displayInfo("Copied!");
+            return false;
         });
     }
 

--- a/app/static/assets/js/view-grades.js
+++ b/app/static/assets/js/view-grades.js
@@ -98,9 +98,17 @@ $(function () {
         });
 
         $("#vg-copy-url-form").on("submit", () => {
-            navigator.clipboard.writeText(document.location.href);
-            displayInfo("Copied!");
+            try {
+                navigator.clipboard.writeText(document.location.href);
+                displayInfo("Copied!");
+            } catch (e) {
+                displayError("Failed to copy, try manually.");
+            }
             return false;
+        });
+
+        $("#vg-copy-url-input").on("click", (e) => {
+            e.target.setSelectionRange(0, e.target.value.length)
         });
     }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -432,7 +432,7 @@
             <div class="card-body" id="vg-copy-url-form">
               <form class="row">
                 <div class="col-lg col-8">
-                  <input id="vg-copy-url-input" type="text" disabled class="form-control" aria-label="URL" aria-describedby="basic-addon1">
+                  <input id="vg-copy-url-input" readonly type="text" class="form-control" aria-label="URL" aria-describedby="basic-addon1">
                 </div>
                 <div class="col-lg-2 col-4 text-center">
                   <button id="vg-copy-url-submit" class="submit-margin btn btn-block btn-xl btn-primary" type="submit">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -426,7 +426,26 @@
           </div>
         </div>
       </div>
+      <div class="row mb-4">
+        <div class="col">
+          <div class="card shadow" id="vg-copy-url">
+            <div class="card-body" id="vg-copy-url-form">
+              <form class="row">
+                <div class="col-lg col-8">
+                  <input id="vg-copy-url-input" type="text" disabled class="form-control" aria-label="URL" aria-describedby="basic-addon1">
+                </div>
+                <div class="col-lg-2 col-4 text-center">
+                  <button id="vg-copy-url-submit" class="submit-margin btn btn-block btn-xl btn-primary" type="submit">
+                    Copy
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 
     {% include "site_template/footer.html" %}
   </div>

--- a/app/templates/statistics_by_course.html
+++ b/app/templates/statistics_by_course.html
@@ -164,7 +164,7 @@
             <div class="card-body" id="sc-copy-url-form">
               <form class="row">
                 <div class="col-lg col-8">
-                  <input id="sc-copy-url-input" type="text" disabled class="form-control" aria-label="URL" aria-describedby="basic-addon1">
+                  <input id="sc-copy-url-input" readonly type="text" class="form-control" aria-label="URL" aria-describedby="basic-addon1">
                 </div>
                 <div class="col-lg-2 col-4 text-center">
                   <button id="sc-copy-url-submit" class="submit-margin btn btn-block btn-xl btn-primary" type="submit">

--- a/app/templates/statistics_by_course.html
+++ b/app/templates/statistics_by_course.html
@@ -142,7 +142,7 @@
         </div>
       </div>
 
-      <div class="row">
+      <div class="row mb-4">
         <div class="col">
           <div class="card shadow" id="teaching-team">
             <div class="card-header border-0">
@@ -157,7 +157,27 @@
           </div>
         </div>
       </div>
+
+      <div class="row mb-4">
+        <div class="col">
+          <div class="card shadow" id="sc-copy-url">
+            <div class="card-body" id="sc-copy-url-form">
+              <form class="row">
+                <div class="col-lg col-8">
+                  <input id="sc-copy-url-input" type="text" disabled class="form-control" aria-label="URL" aria-describedby="basic-addon1">
+                </div>
+                <div class="col-lg-2 col-4 text-center">
+                  <button id="sc-copy-url-submit" class="submit-margin btn btn-block btn-xl btn-primary" type="submit">
+                    Copy
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+
 
     {% include "site_template/footer.html" %}
 


### PR DESCRIPTION
Some quality of life improvements for the website. The biggest change architecturally is that a new class, the `StateHandler`, handles the app's state now, which means the requests and response handlers are orchestrated by the handler now instead of being coupled. The grades and course pages are different enough that I just duplicated the `StateHandler`.

Functionality-wise, the app will now:
- Perform a best-effort resolution of the year, subject, course, and section (in that order). The dropdown will be shown on the first failure (like the previous behavior)
- Cache API requests so that students can switch between different sections much quicker (only for the view-grades page)
- Push valid state combinations to the browser history so that browser navigation works
- Allow sharing of specific grade pages
- Have an additional card that has the share URL and a copy button (I'm pretty bad at design so this was my first thought; it can probably be a simple icon somewhere else)
- Automatically submit once sections are supported (even for courses with multiple sections)

Tested on Chrome, Safari, and FF.